### PR TITLE
Add arrays for AoI visualization

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,54 @@ const layerRadius = d3.scalePoint()
   .domain(layers)
   .range([size, 80]);             // 外→内
 
-d3.json("data/infra.json").then(draw);
+// 各レイヤーの要素を配列で定義
+const micro = [
+  "東京湾マリーナ",
+  "地下鉄駅",
+  "住宅地"
+];
+
+const affordance = [
+  "マリーナ内活動",
+  "交通ハブ",
+  "生活利便"
+];
+
+const impact = [
+  "リズムのある街並み",
+  "都市の回遊性向上",
+  "コミュニティ活性"
+];
+
+const goal = [
+  "自己実現ある暮らしの促進",
+  "都市の持続可能性"
+];
+
+// 要素間の関連をリンクとして定義
+const links = [
+  { source: "東京湾マリーナ", target: "マリーナ内活動" },
+  { source: "地下鉄駅",     target: "交通ハブ" },
+  { source: "住宅地",       target: "生活利便" },
+
+  { source: "マリーナ内活動", target: "リズムのある街並み" },
+  { source: "交通ハブ",       target: "都市の回遊性向上" },
+  { source: "生活利便",       target: "コミュニティ活性" },
+
+  { source: "リズムのある街並み", target: "自己実現ある暮らしの促進" },
+  { source: "都市の回遊性向上",   target: "都市の持続可能性" },
+  { source: "コミュニティ活性",   target: "都市の持続可能性" }
+];
+
+// 各レイヤーの配列をまとめてノード化
+const nodes = [
+  ...micro.map(id => ({ id, layer: "Micro" })),
+  ...affordance.map(id => ({ id, layer: "Affordance" })),
+  ...impact.map(id => ({ id, layer: "Impact" })),
+  ...goal.map(id => ({ id, layer: "Goal" }))
+];
+
+draw({ nodes, links });
 
 function polarToCartesian(angle, radius) {
   return [radius * Math.cos(angle - Math.PI/2),


### PR DESCRIPTION
## Summary
- represent AoI data directly in app.js
- build node/edge list from Micro, Affordance, Impact, and Goal arrays

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68564b7fa8fc833183fe1a255007b23a