### PR TITLE
Fix undefined node links causing runtime error

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,13 +61,16 @@ function draw({ nodes, links }) {
     .angle(d => d.angle)
     .radius(d => d.radius);
 
+  const filteredLinks = links.map(l => ({
+      source: nodes.find(n => n.id === l.source),
+      target: nodes.find(n => n.id === l.target)
+    }))
+    .filter(l => l.source && l.target);
+
   svg.append("g")
     .attr("class", "links")
     .selectAll("path")
-    .data(links.map(l => ({
-      source: nodes.find(n => n.id === l.source),
-      target: nodes.find(n => n.id === l.target)
-    })))
+    .data(filteredLinks)
     .enter().append("path")
     .attr("d", linkGen)
     .attr("class", "link")


### PR DESCRIPTION
## Summary
- guard against links that reference missing nodes

## Testing
- `node --version`
- `node - <<'NODE'
const data=require('./data/infra.json');
const ids=new Set(data.nodes.map(n=>n.id));
console.log('missing',data.links.filter(l=>!ids.has(l.source)||!ids.has(l.target)).length);
NODE
`

------
https://chatgpt.com/codex/tasks/task_e_6857f3af199c833188fb8493c7e4d907