### PR TITLE
Spread nodes and scale inner text

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 const svg = d3.select("#viz");
-const size = 350;
+const size = 500; // increase overall radius for more spacing between nodes
 
 // レイヤー構造（外側から内側へ）
 const layers = ["Micro", "Affordance", "Impact", "Goal"];
@@ -13,6 +13,14 @@ const layerRadiusByName = {
   Affordance: (ringRadii[1] + ringRadii[2]) / 2,
   Impact: (ringRadii[2] + ringRadii[3]) / 2,
   Goal: 0
+};
+
+// フォントサイズをレイヤー毎に指定
+const fontSizeByLayer = {
+  Micro: 12,
+  Affordance: 14,
+  Impact: 16,
+  Goal: 18
 };
 
 // カテゴリごとの色設定
@@ -103,6 +111,7 @@ function draw({ nodes, links }) {
     .attr("dy", "-0.8em")
     .attr("text-anchor", "middle")
     .attr("fill", "#999")
+    .style("font-size", d => `${fontSizeByLayer[d.layer]}px`)
     .style("pointer-events", "none");
 
   // 凡例

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <!-- Center the visualization by using a symmetric viewBox -->
   <!-- Increase the physical drawing area to roughly six times the
        previous size by enlarging width and height -->
-  <svg id="viz" width="2200" height="2200" viewBox="-450 -450 900 900"></svg>
+  <svg id="viz" width="2200" height="2200" viewBox="-650 -650 1300 1300"></svg>
   <script type="module" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expand the SVG viewBox for additional space
- enlarge radial radius used for layout
- vary text size based on layer so labels closer to the center are larger

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857f70fce748331b829998040b0812b