### PR TITLE
Fix dataset loading by using explicit index

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,14 +21,8 @@ async function init() {
 init();
 
 async function fetchDatasets() {
-  const res = await fetch("data/");
-  const text = await res.text();
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(text, "text/html");
-  return Array.from(doc.querySelectorAll("a"))
-    .map(a => a.getAttribute("href"))
-    .filter(h => h && h.endsWith(".json"))
-    .map(h => `data/${h}`);
+  const files = await d3.json("data/datasets.json");
+  return files.map(f => `data/${f}`);
 }
 
 function loadAndDraw(path) {

--- a/data/datasets.json
+++ b/data/datasets.json
@@ -1,0 +1,4 @@
+[
+  "sample.json",
+  "infra.json"
+]


### PR DESCRIPTION
## Summary
- added `datasets.json` to list available data files
- updated `fetchDatasets()` to read this index instead of relying on directory listings

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_68592ccbbafc8331b49cdf52a3970dc2